### PR TITLE
To unpack rar files, install unrar package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk -U upgrade && \
     apk -U add \
         ca-certificates \
         py-pip ca-certificates git python py-libxml2 py-lxml \
-        make gcc g++ python-dev openssl-dev libffi-dev \
+        make gcc g++ python-dev openssl-dev libffi-dev unrar \
         && \
     pip --no-cache-dir install pyopenssl cheetah && \
     git clone --depth 1 http://github.com/SiCKRAGETV/SickRage /sickrage && \


### PR DESCRIPTION
Got the following error when downloading rar archives:
Rar Not Supported: No suitable RAR unpacker installed

Installing unrar fixes it.