### PR TITLE
FIX "pip install fails: invalid command egg_info"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk -U upgrade && \
         py-pip ca-certificates git python py-libxml2 py-lxml \
         make gcc g++ python-dev openssl-dev libffi-dev unrar \
         && \
+    pip install --upgrade setuptools && \
     pip --no-cache-dir install pyopenssl cheetah requirements && \
     git clone --depth 1 https://github.com/SickRage/SickRage.git /sickrage && \
     apk del make gcc g++ python-dev && \


### PR DESCRIPTION
egg_info  from Distribute is part of setuptool 7.0+