### PR TITLE
Added support to run sickrage as a different user

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ docker build -t sickrage .
 
 docker run --restart=always -d -h *your_host_name* -v /*your_config_location*:/config  -v /*your_videos_location*:/data -p 8081:8081 sickrage
 
+Optional environment variables (use `-e` with `docker run`):
+```
+PUID    - User ID to run as (default: 0)
+GUID    - Group ID to run as (default: 0)
+```
+

--- a/start.sh
+++ b/start.sh
@@ -19,4 +19,26 @@ touch /config/sickbeard.db.v42
 touch /config/sickbeard.db.v43
 touch /config/sickbeard.db.v44
 
-/usr/bin/python /sickrage/SickBeard.py --datadir=/config/ --config=/config/config.ini
+#                             
+# Set up the user to run Sickrage as
+#                                   
+if [ "x$PUID" = "x" ]; then   
+  export PUID=0               
+fi                            
+if [ "x$GUID" = "x" ]; then   
+  export GUID=0               
+fi                            
+                              
+chown -R "${PUID}":"${GUID}" /config
+                                    
+# First, we remove any existing sickrage entries to avoid duplicates
+sed -i '/^sickrage/d' /etc/passwd                                   
+                                    
+# We need to add the user because busybox's su does not accept UID numbers
+echo "sickrage:x:${PUID}:${GUID}:Sickrage user:/dev/null:/bin/sh" >>/etc/passwd
+
+#                           
+# Start Sickrage
+#
+su sickrage -c "/usr/bin/python /sickrage/SickBeard.py --datadir=/config/ --config=/config/config.ini"
+


### PR DESCRIPTION
Added support to run Sickrage as a different user to help integration with other tools.

Remarks:
- `start.sh:32`: When debugging the container by running `start.sh` multiple times, the user gets added to `/etc/password` multiple times
- `start.sh:38`: unfortunately `sh` does not support heredocs, so I had to use `echo`