### PR TITLE
The latest sickrage docker image no longer has SickBeard.py

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -19,4 +19,4 @@ touch /config/sickbeard.db.v42
 touch /config/sickbeard.db.v43
 touch /config/sickbeard.db.v44
 
-/usr/bin/python /sickrage/SickBeard.py --datadir=/config/ --config=/config/config.ini
+/usr/bin/python /sickrage/SiCKRAGE.py --datadir=/config/ --config=/config/config.ini


### PR DESCRIPTION
```
/ # ls /sickrage/
COPYING.txt         Gruntfile.js        README.txt          changelog.md        package-lock.json   pre-commit-hook.sh  requirements.txt    setup.cfg           sickrage            tests
Dockerfile          MANIFEST.in         SiCKRAGE.py         crowdin.yaml        package.json        readme.md           runscripts          setup.py            src                 webpack.config.js
```